### PR TITLE
Fix getRandomColor so it returns ColorRGBA

### DIFF
--- a/src/rviz_tools_py/rviz_tools.py
+++ b/src/rviz_tools_py/rviz_tools.py
@@ -300,7 +300,7 @@ class RvizMarkers(object):
         """
         Return a ROS ColorRGBA type from a color name, RGB value or a ROS ColorRGBA value
 
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
 
         @return color (ColorRGBA)
         """

--- a/src/rviz_tools_py/rviz_tools.py
+++ b/src/rviz_tools_py/rviz_tools.py
@@ -62,6 +62,8 @@ class RvizMarkers(object):
         # Create the Rviz Marker Publisher
         self.loadMarkerPublisher(wait_time)
 
+        # Make a list of the color names to choose from
+        self.all_colors = ['red', 'green', 'blue', 'grey', 'white', 'orange', 'yellow', 'brown', 'pink', 'lime_green', 'purple']
 
     def setDefaultMarkerParams(self):
         """
@@ -409,26 +411,11 @@ class RvizMarkers(object):
 
         @return color (ColorRGBA)
         """
-
-        # Make a list of the color names to choose from
-        all_colors = []
-        all_colors.append('red')
-        all_colors.append('green')
-        all_colors.append('blue')
-        all_colors.append('grey')
-        all_colors.append('white')
-        all_colors.append('orange')
-        all_colors.append('yellow')
-        all_colors.append('brown')
-        all_colors.append('pink')
-        all_colors.append('lime_green')
-        all_colors.append('purple')
-
         # Chose a random color name
-        rand_num =  random.randint(0, len(all_colors) - 1)
-        rand_color_name = all_colors[rand_num]
+        rand_num =  random.randint(0, len(self.all_colors) - 1)
+        rand_color_name = self.all_colors[rand_num]
 
-        return rand_color_name
+        return self.getColor(rand_color_name)
 
 
     def publishSphere(self, pose, color, scale, lifetime=None):
@@ -1382,3 +1369,4 @@ def mat_to_pose(mat):
     pose.orientation.w = quat[3]
 
     return pose
+

--- a/src/rviz_tools_py/rviz_tools.py
+++ b/src/rviz_tools_py/rviz_tools.py
@@ -298,12 +298,15 @@ class RvizMarkers(object):
 
     def getColor(self, color):
         """
-        Convert a color name or RGB value to a ROS ColorRGBA type
+        Return a ROS ColorRGBA type from a color name, RGB value or a ROS ColorRGBA value
 
         @param color name (string) or RGB color value (tuple or list)
 
         @return color (ColorRGBA)
         """
+
+        if type(color) is ColorRGBA:
+            return color
 
         result = ColorRGBA()
         result.a = self.alpha
@@ -423,7 +426,7 @@ class RvizMarkers(object):
         Publish a sphere Marker. This renders 3D looking sphere.
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -484,7 +487,7 @@ class RvizMarkers(object):
         Publish a sphere Marker. This renders a smoother, flatter-looking sphere.
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -546,7 +549,7 @@ class RvizMarkers(object):
         Publish an arrow Marker.
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -603,7 +606,7 @@ class RvizMarkers(object):
         Publish a cube Marker.
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -660,7 +663,7 @@ class RvizMarkers(object):
         Publish a list of cubes.
 
         @param list_of_cubes (list of numpy matrix, list of numpy ndarray, list of ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -732,7 +735,7 @@ class RvizMarkers(object):
         Publish a cube Marker.
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -745,7 +748,7 @@ class RvizMarkers(object):
         Publish a cylinder Marker.
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param height (float)
         @param radius (float)
         @param lifetime (float, None = never expire)
@@ -837,7 +840,7 @@ class RvizMarkers(object):
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
         @param file_name (string)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -902,7 +905,7 @@ class RvizMarkers(object):
 
         @param point1 (ROS Point)
         @param point2 (ROS Point)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param lifetime (float, None = never expire)
         """
 
@@ -960,7 +963,7 @@ class RvizMarkers(object):
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
         @param depth (float)
         @param width (float)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param lifetime (float, None = never expire)
         """
 
@@ -1010,7 +1013,7 @@ class RvizMarkers(object):
 
         @param point1 (ROS Point, ROS Pose, numpy matrix, numpy ndarray)
         @param point2 (ROS Point, ROS Pose, numpy matrix, numpy ndarray)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param width (float)
         @param lifetime (float, None = never expire)
         """
@@ -1078,7 +1081,7 @@ class RvizMarkers(object):
         Publish a path Marker using a set of waypoints.
 
         @param path (list of ROS Points)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param width (float)
         @param lifetime (float, None = never expire)
         """
@@ -1161,7 +1164,7 @@ class RvizMarkers(object):
         Publish a polygon Marker.
 
         @param polygon (ROS Polygon)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param width line width (float)
         @param lifetime (float, None = never expire)
 
@@ -1200,7 +1203,7 @@ class RvizMarkers(object):
         Publish a list of spheres. This renders smoother, flatter-looking spheres.
 
         @param list_of_spheres (list of numpy matrix, list of numpy ndarray, list of ROS Pose)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -1274,7 +1277,7 @@ class RvizMarkers(object):
 
         @param pose (numpy matrix, numpy ndarray, ROS Pose)
         @param text (string)
-        @param color name (string) or RGB color value (tuple or list)
+        @param color name (string), RGB color value (tuple or list) or ROS ColorRGBA type
         @param scale (ROS Vector3, float)
         @param lifetime (float, None = never expire)
         """
@@ -1369,4 +1372,3 @@ def mat_to_pose(mat):
     pose.orientation.w = quat[3]
 
     return pose
-


### PR DESCRIPTION
getRandomColor() is described as a function that returns a **ColorRGBA** color rather than a color name.

This pull request fixed the problem and moved the color name list to the class, so it does not need to be constructed every time the getRandomColor() is called.

Since now getRandomColor returns a ColorRGBA type properly, for ease of use (e.g. call getRandomColor() directly in any publish marker functions, like what the demo.py demonstrates in random color cylinder method 1), getColor() now handles ColorRGBA type as well.